### PR TITLE
feat: add CRUD for lesson

### DIFF
--- a/src/assets/data/defaultLessons.json
+++ b/src/assets/data/defaultLessons.json
@@ -1,0 +1,376 @@
+[
+  {
+    "id": "5212ae0b-6cf4-4de1-8799-36cb6a5ace0a",
+    "title": "Lesson 1: Greetings",
+    "level": "beginner",
+    "description": "Learn how to greet people in different situations and contexts.",
+    "score": 0,
+    "content": [
+      "Greetings are an important way to start a conversation and show respect and courtesy towards others. Here are some common greetings you can use:",
+      "Ciao",
+      "It's the most common informal greeting. It can be used to say both hello and goodbye. For example: Ciao, how are you? or Ciao, see you later!",
+      "Buongiorno",
+      "It means good morning and is used in the morning until midday. It can be shortened to Buon giorno. For example: Buongiorno, how are you today?",
+      "Buonasera",
+      "This means good evening and is used in the late afternoon and evening. For example: Buonasera, how was your day?",
+      "Buonanotte",
+      "It means goodnight and is used when saying goodbye in the evening or before going to bed. For example: Buonanotte, sleep well!",
+      "Salve",
+      "This is a neutral and formal greeting that can be used at any time of the day. It's a bit like saying hello. For example: Salve, nice to meet you."
+    ],
+    "tests": [
+      {
+        "question": "What does 'Ciao' mean?",
+        "options": ["Good morning", "Hello", "Good afternoon", "Good evening"],
+        "answer": "Hello"
+      },
+      {
+        "question": "When can you use 'Buongiorno'?",
+        "options": [
+          "In the morning",
+          "In the afternoon",
+          "In the evening",
+          "At night"
+        ],
+        "answer": "In the morning"
+      },
+      {
+        "question": "What is 'Salve' similar to?",
+        "options": ["Good morning", "Hello", "Good afternoon", "Good evening"],
+        "answer": "Hello"
+      }
+    ]
+  },
+  {
+    "id": "ce64a603-d523-4ee8-8b87-7698fee2d39d",
+    "title": "Lesson 15: Travel",
+    "level": "intermediate",
+    "description": "Learn how to ask for directions and order food at a restaurant.",
+    "score": 0,
+    "content": [
+      "When traveling to a foreign country, it's important to know how to ask for directions and order food at a restaurant. Here are some useful phrases you can use:",
+      "Italian",
+      "Scusi, dov'è la stazione?",
+      "English",
+      "Excuse me, where is the train station?",
+      "Italian",
+      "Mi scusi, come si arriva al museo?",
+      "English",
+      "Excuse me, how do I get to the museum?",
+      "Italian",
+      "Vorrei prenotare un tavolo per due, per favore.",
+      "English",
+      "I would like to book a table for two, please."
+    ],
+    "tests": [
+      {
+        "question": "What does 'Scusi, dov'è la stazione?' mean?",
+        "options": [
+          "Where is the train station?",
+          "How do I get to the museum?",
+          "Can I book a table for two?",
+          "How are you?"
+        ],
+        "answer": "Where is the train station?"
+      },
+      {
+        "question": "What does 'Vorrei prenotare un tavolo per due, per favore.' mean?",
+        "options": [
+          "Where is the train station?",
+          "How do I get to the museum?",
+          "I would like to book a table for two, please.",
+          "How are you?"
+        ],
+        "answer": "I would like to book a table for two, please."
+      }
+    ]
+  },
+  {
+    "id": "adf519b0-a093-4217-ab52-f6b97146ab3b",
+    "title": "Lesson 30: Business",
+    "level": "advanced",
+    "description": "Learn how to write a professional email and give a presentation.",
+    "score": 0,
+    "content": [
+      "In order to succeed in the business world, it's important to know how to write a professional email and give a presentation. Here are some tips to help you:",
+      "Introduction", "Buongiorno a tutti, oggi parleremo di...", "Good morning everyone, today we will talk about...",
+      "Body", "Il nostro obiettivo è...", "Our goal is...",
+      "Conclusion", "Grazie per l'attenzione.", "Thank you for your attention."
+    ],
+    "tests": [
+      {
+        "question": "What does 'Buongiorno a tutti, oggi parleremo di...' mean?",
+        "options": [
+          "Good morning everyone, today we will talk about...",
+          "Our goal is...",
+          "Thank you for your attention.",
+          "How are you?"
+        ],
+        "answer": "Good morning everyone, today we will talk about..."
+      },
+      {
+        "question": "What does 'Il nostro obiettivo è...' mean?",
+        "options": [
+          "Good morning everyone, today we will talk about...",
+          "Our goal is...",
+          "Thank you for your attention.",
+          "How are you?"
+        ],
+        "answer": "Our goal is..."
+      }
+    ]
+  },
+  {
+    "id": "d4032bbb-6266-4d8b-a6a3-0edae1ec9f8e",
+    "title": "Lesson 2: Numbers",
+    "level": "beginner",
+    "description": "Learn how to count from 1 to 10 in Italian.",
+    "score": 0,
+    "content": [
+      "Numbers are an essential part of everyday life. Here are the numbers from 1 to 10 in Italian:",
+      "uno - one",
+      "due - two",
+      "tre - three",
+      "quattro - four",
+      "cinque - five",
+      "sei - six",
+      "sette - seven",
+      "otto - eight",
+      "nove - nine",
+      "dieci - ten"
+    ],
+    "tests": [
+      {
+        "question": "What does 'uno' mean?",
+        "options": ["one", "two", "three", "four"],
+        "answer": "one"
+      },
+      {
+        "question": "What does 'cinque' mean?",
+        "options": ["one", "two", "three", "five"],
+        "answer": "five"
+      },
+      {
+        "question": "What does 'otto' mean?",
+        "options": ["six", "seven", "eight", "nine"],
+        "answer": "eight"
+      }
+    ]
+  },
+  {
+    "id": "6e23b6f3-e344-4b4c-b715-7fa0e7bfac4f",
+    "title": "Lesson 3: Colors",
+    "level": "beginner",
+    "description": "Learn how to say colors in Italian.",
+    "score": 0,
+    "content": [
+      "Colors are all around us and can be used to describe objects and emotions. Here are some common colors in Italian:",
+      "rosso - red",
+      "blu - blue",
+      "giallo - yellow",
+      "verde - green",
+      "arancione - orange",
+      "viola - purple",
+      "nero - black",
+      "bianco - white",
+      "grigio - gray"
+    ],
+    "tests": [
+      {
+        "question": "What does 'rosso' mean?",
+        "options": ["red", "blue", "yellow", "green"],
+        "answer": "red"
+      },
+      {
+        "question": "What does 'giallo' mean?",
+        "options": ["red", "blue", "yellow", "green"],
+        "answer": "yellow"
+      },
+      {
+        "question": "What does 'nero' mean?",
+        "options": ["black", "white", "gray", "purple"],
+        "answer": "black"
+      }
+    ]
+  },
+  {
+    "id": "e88804da-d6e6-4f58-9d72-a156a8756343",
+    "title": "Lesson 10: Family",
+    "level": "intermediate",
+    "description": "Learn how to talk about your family in Italian.",
+    "score": 0,
+    "content": [
+      "Family is an important part of Italian culture. Here are some common family members and relationships:",
+      "madre - mother",
+      "padre - father",
+      "figlio - son",
+      "figlia - daughter",
+      "nonno - grandfather",
+      "nonna - grandmother",
+      "zio - uncle",
+      "zia - aunt",
+      "cugino - cousin"
+    ],
+    "tests": [
+      {
+        "question": "What does 'madre' mean?",
+        "options": ["mother", "father", "son", "daughter"],
+        "answer": "mother"
+      },
+      {
+        "question": "What does 'nonno' mean?",
+        "options": ["grandfather", "grandmother", "uncle", "aunt"],
+        "answer": "grandfather"
+      },
+      {
+        "question": "What does 'cugino' mean?",
+        "options": ["mother", "father", "son", "cousin"],
+        "answer": "cousin"
+      }
+    ]
+  }, 
+  {
+    "id": "127e2cf6-1cfa-450e-8f4b-77758fbfe2e3",
+    "title": "Lesson 33: Health",
+    "level": "advanced",
+    "description": "Learn how to talk about health and wellness in Italian.",
+    "score": 0,
+    "content": [
+      "Health is an important aspect of life. Here are some common phrases and vocabulary related to health and wellness:",
+      "Italian",
+      "Mi fa male la testa.",
+      "English",
+      "I have a headache.",
+      "Italian",
+      "Ho la febbre.",
+      "English",
+      "I have a fever.",
+      "Italian",
+      "Mi sento stanco.",
+      "English",
+      "I feel tired."
+    ],
+    "tests": [
+      {
+        "question": "What does 'Mi fa male la testa.' mean?",
+        "options": [
+          "I have a headache.",
+          "I have a fever.",
+          "I feel tired.",
+          "I feel sick."
+        ],
+        "answer": "I have a headache."
+      },
+      {
+        "question": "What does 'Ho la febbre.' mean?",
+        "options": [
+          "I have a headache.",
+          "I have a fever.",
+          "I feel tired.",
+          "I feel sick."
+        ],
+        "answer": "I have a fever."
+      },
+      {
+        "question": "What does 'Mi sento stanco.' mean?",
+        "options": [
+          "I have a headache.",
+          "I have a fever.",
+          "I feel tired.",
+          "I feel sick."
+        ],
+        "answer": "I feel tired."
+      }
+    ]
+  },
+  {
+    "id": "7808af28-9981-49e3-8f88-0b563a0922e5",
+    "title": "Lesson 20: Food",
+    "level": "intermediate",
+    "description": "Learn how to order food at a restaurant and talk about Italian cuisine.",
+    "score": 0,
+    "content": [
+      "Italian cuisine is known for its delicious food and rich flavors. Here are some common dishes and ingredients you can find in Italy:",
+      "pasta - pasta",
+      "pizza - pizza",
+      "risotto - risotto",
+      "panna - cream",
+      "formaggio - cheese",
+      "olio d'oliva - olive oil",
+      "pomodoro - tomato",
+      "basilico - basil",
+      "mozzarella - mozzarella"
+    ],
+    "tests": [
+      {
+        "question": "What does 'pasta' mean?",
+        "options": ["pasta", "pizza", "risotto", "cream"],
+        "answer": "pasta"
+      },
+      {
+        "question": "What does 'olio d'oliva' mean?",
+        "options": ["cream", "cheese", "olive oil", "tomato"],
+        "answer": "olive oil"
+      },
+      {
+        "question": "What does 'mozzarella' mean?",
+        "options": ["cheese", "basil", "tomato", "mozzarella"],
+        "answer": "mozzarella"
+      }
+    ]
+  },
+  {
+    "id": "53ca3a40-eabc-4ab7-ac9e-3f8fdaf13734",
+    "title": "Lesson 12: Weather",
+    "level": "intermediate",
+    "description": "Learn how to talk about the weather in Italian.",
+    "score": 0,
+    "content": [
+      "The weather can affect our mood and daily activities. Here are some common phrases and vocabulary related to the weather:",
+      "Italian",
+      "Che tempo fa oggi?",
+      "English",
+      "What's the weather like today?",
+      "Italian",
+      "Fa caldo.",
+      "English",
+      "It's hot.",
+      "Italian",
+      "Piove.",
+      "English",
+      "It's raining."
+    ],
+    "tests": [
+      {
+        "question": "What does 'Che tempo fa oggi?' mean?",
+        "options": [
+          "What's the weather like today?",
+          "It's hot.",
+          "It's raining.",
+          "It's cold."
+        ],
+        "answer": "What's the weather like today?"
+      },
+      {
+        "question": "What does 'Fa caldo.' mean?",
+        "options": [
+          "What's the weather like today?",
+          "It's hot.",
+          "It's raining.",
+          "It's cold."
+        ],
+        "answer": "It's hot."
+      },
+      {
+        "question": "What does 'Piove.' mean?",
+        "options": [
+          "What's the weather like today?",
+          "It's hot.",
+          "It's raining.",
+          "It's cold."
+        ],
+        "answer": "It's raining."
+      }
+    ]
+  }
+]

--- a/src/components/lesson/Lesson.jsx
+++ b/src/components/lesson/Lesson.jsx
@@ -1,9 +1,10 @@
-import React from "react";
-import { useState } from "react";
+import React, { useState } from "react";
 import "../../css/lesson/Lesson.css";
 import LessonDialog from "./LessonDialog";
+import LessonDelete from "./LessonDelete";
+import LessonEdit from "./LessonEdit";
 
-const Lesson = ({ index, lesson }) => {
+const Lesson = ({ lesson, updateLesson, updateLessonScore, deleteLesson }) => {
   let scoreClass = "";
   if (lesson.score < 30) {
     scoreClass = "low";
@@ -25,7 +26,7 @@ const Lesson = ({ index, lesson }) => {
 
   return (
     <div className="lesson-wrapper">
-      <div key={index} className="lesson" onClick={handleClickOpen}>
+      <div className="lesson">
         <h3 className="lesson-title">{lesson.title}</h3>
         <p
           className={`lesson-level lesson-level-${lesson.level.toLowerCase()}`}
@@ -35,8 +36,15 @@ const Lesson = ({ index, lesson }) => {
         <p className="lesson-desc">{lesson.description}</p>
         <p className="lesson-score">
           Score:{" "}
-          <span className={`lesson-score-${scoreClass}`}>{lesson.score}</span>
+          <span className={`lesson-score-${scoreClass}`}>{lesson.score}/100</span>
         </p>
+        <div className="lesson-operations-wrapper">
+          <button className="start-lesson-btn" onClick={handleClickOpen}>Start lesson</button>
+          <div className="lesson-operations">
+            <LessonEdit lesson={lesson} updateLesson={updateLesson} />
+            <LessonDelete deleteLesson={() => deleteLesson(lesson.id)} />
+          </div>
+        </div>
       </div>
 
       <LessonDialog
@@ -44,6 +52,7 @@ const Lesson = ({ index, lesson }) => {
         handleClose={handleClose}
         lesson={lesson}
         scoreClass={scoreClass}
+        updateLessonScore={updateLessonScore}
       />
     </div>
   );

--- a/src/components/lesson/LessonAdd.jsx
+++ b/src/components/lesson/LessonAdd.jsx
@@ -1,0 +1,335 @@
+import React, { useState } from "react";
+import IconButton from "@mui/material/IconButton";
+import AddIcon from "@mui/icons-material/Add";
+import { Tooltip } from "@mui/material";
+import "../../css/lesson/LessonAdd.css";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText";
+import DialogTitle from "@mui/material/DialogTitle";
+import Radio from "@mui/material/Radio";
+import RadioGroup from "@mui/material/RadioGroup";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import FormControl from "@mui/material/FormControl";
+import FormLabel from "@mui/material/FormLabel";
+import DeleteIcon from "@mui/icons-material/Delete";
+
+const LessonAdd = ({ addLesson }) => {
+  const [open, setOpen] = useState(false);
+  const [selectedLevel, setSelectedLevel] = useState(null);
+  const [tests, setTests] = useState([]);
+  const [options, setOptions] = useState([]);
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+
+    const formElement = document.getElementById("add-lesson-form");
+    const formData = new FormData(formElement);
+    const formJson = Object.fromEntries(formData.entries());
+    const { addTitle, addDescription, addLevel, addContent } = formJson;
+
+    if (
+      !addTitle ||
+      !addLevel ||
+      !addDescription ||
+      !addContent ||
+      tests.length === 0
+    ) {
+      alert("Please fill in all fields and ensure there is at least one test.");
+      return;
+    }
+
+    const newLesson = {
+      id: Date.now(),
+      title: addTitle,
+      level: addLevel,
+      description: addDescription,
+      content: addContent.split("\n"),
+      tests: tests,
+      score: 0,
+    };
+
+    handleClose();
+    addLesson(newLesson);
+    formElement.reset();
+    setTests([]);
+    setSelectedLevel(null);
+  };
+
+  const handleAddOption = () => {
+    const optionsInput = document.getElementById("addOption").value;
+
+    if (!optionsInput) {
+      alert("Please make sure the option is not empty.");
+      return;
+    }
+
+    setOptions([...options, optionsInput]);
+    document.getElementById("addOption").value = "";
+  };
+
+  const handleAddTest = () => {
+    const questionInput = document.getElementById("addQuestion").value;
+    const answerInput = document.getElementById("addAnswer").value;
+
+    if (!questionInput || !answerInput) {
+      alert(
+        "Please make sure the question and answer are not empty."
+      );
+      return;
+    }
+
+    if (options.length < 2) {
+      alert("Please make sure there are at least two options.");
+      return;
+    }
+
+    const newTest = {
+      question: questionInput,
+      options: options,
+      answer: answerInput,
+    };
+
+    setTests([...tests, newTest]);
+
+    // Clear the input fields after adding the test
+    document.getElementById("addQuestion").value = "";
+    document.getElementById("addAnswer").value = "";
+    setOptions([]);
+  };
+
+  const handleDeleteTest = (index) => {
+    setTests(tests.filter((_, i) => i !== index));
+  };
+
+  const handleDeleteOption = (index) => {
+    setOptions(options.filter((_, i) => i !== index));
+  };
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <div className="lesson-add">
+      <h3 className="lesson-add-title">Add a lesson:</h3>
+      <Tooltip title="Add Lesson">
+        <IconButton
+          edge="start"
+          color="success"
+          size="large"
+          aria-label="close"
+          className="add-lesson-btn"
+          onClick={handleClickOpen}
+        >
+          <AddIcon className="lesson-add-icon" />
+        </IconButton>
+      </Tooltip>
+
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        PaperProps={{
+          component: "form",
+          onSubmit: handleSubmit,
+          id: "add-lesson-form",
+        }}
+      >
+        <DialogTitle className="add-lesson-dialog-title">
+          Add a lesson
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText className="add-lesson-dialog-tip">
+            Enter a title, level, description, content and the tests for the new
+            lesson.
+          </DialogContentText>
+          <FormControl className="add-lesson-dialog-form">
+            <TextField
+              className="add-lesson-dialog-textfield"
+              autoFocus
+              required
+              fullWidth
+              margin="dense"
+              id="addTitle"
+              name="addTitle"
+              label="Title"
+              type="text"
+              variant="outlined"
+            />
+
+            <TextField
+              className="add-lesson-dialog-textfield"
+              required
+              margin="dense"
+              id="addDescription"
+              name="addDescription"
+              label="Description"
+              type="text"
+              variant="outlined"
+            />
+
+            <FormLabel id="add-lesson-dialog-level">Level</FormLabel>
+            <RadioGroup
+              className="add-lesson-dialog-radio-group"
+              aria-labelledby="add-lesson-group-label"
+              name="addLevel"
+              value={selectedLevel}
+              onChange={(event) => setSelectedLevel(event.target.value)}
+            >
+              <FormControlLabel
+                id="beginner-radio"
+                value="beginner"
+                control={<Radio />}
+                label="Beginner"
+              />
+              <FormControlLabel
+                id="intermediate-radio"
+                value="intermediate"
+                control={<Radio />}
+                label="Intermediate"
+              />
+              <FormControlLabel
+                id="advanced-radio"
+                value="advanced"
+                control={<Radio />}
+                label="Advanced"
+              />
+            </RadioGroup>
+
+            <TextField
+              margin="dense"
+              id="add-lesson-dialog-content"
+              name="addContent"
+              label="Content"
+              type="text"
+              multiline
+              rows={4}
+            />
+
+            <div className="add-lesson-tests-wrapper">
+              <h2 className="add-lesson-test-title">Review</h2>
+              <TextField
+                className="add-lesson-dialog-textfield"
+                margin="dense"
+                id="addQuestion"
+                name="addQuestion"
+                label="Question"
+                type="text"
+                fullWidth
+                variant="outlined"
+              />
+
+              <TextField
+                className="add-lesson-dialog-textfield add-lesson-dialog-answer"
+                margin="dense"
+                id="addAnswer"
+                name="addAnswer"
+                label="Answer"
+                type="text"
+                fullWidth
+                variant="outlined"
+              />
+
+              <div className="add-option-wrapper">
+                <TextField
+                  className="add-lesson-dialog-textfield add-lesson-dialog-option"
+                  margin="dense"
+                  id="addOption"
+                  name="addOption"
+                  label="Option"
+                  type="text"
+                  variant="outlined"
+                />
+                <button className="add-option-btn" type="button" onClick={handleAddOption}>
+                  Add option
+                </button>
+              </div>
+
+              <div className="added-options">
+                {options.length > 0 && (
+                  <h2 className="added-options-title">Options</h2>
+                )}
+                {options.map((option, index) => (
+                  <div key={index} className="added-option">
+                    <p className="added-option-text">
+                      {index + 1}: {option}
+                    </p>
+                    <Tooltip title="Delete Option">
+                      <IconButton
+                        edge="start"
+                        color="error"
+                        size="large"
+                        aria-label="close"
+                        className="delete-option-btn"
+                        onClick={() => handleDeleteOption(index)}
+                      >
+                        <DeleteIcon className="lesson-delete-icon" />
+                      </IconButton>
+                    </Tooltip>
+                  </div>
+                ))}
+              </div>
+ 
+
+              <button
+                className="add-lesson-test-btn"
+                type="button"
+                onClick={handleAddTest}
+              >
+                Add test
+              </button>
+
+              <div className="added-tests">
+                {tests.length > 0 && (
+                  <h2 className="added-tests-title">Tests</h2>
+                )}
+                {tests.map((test, index) => (
+                  <div key={index} className="added-test">
+                    <p className="added-test-question">
+                      {index + 1}: {test.question}
+                    </p>
+                    <Tooltip title="Delete Test">
+                      <IconButton
+                        edge="start"
+                        color="error"
+                        size="large"
+                        aria-label="close"
+                        className="delete-test-btn"
+                        onClick={() => handleDeleteTest(index)}
+                      >
+                        <DeleteIcon className="lesson-delete-icon" />
+                      </IconButton>
+                    </Tooltip>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </FormControl>
+        </DialogContent>
+        <DialogActions>
+          <Button className="add-lesson-dialog-btn" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button
+            className="add-lesson-dialog-btn"
+            color="success"
+            variant="contained"
+            type="submit"
+            onClick={handleSubmit}
+          >
+            Create
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
+
+export default LessonAdd;

--- a/src/components/lesson/LessonDelete.jsx
+++ b/src/components/lesson/LessonDelete.jsx
@@ -1,0 +1,68 @@
+import React from "react";
+import IconButton from "@mui/material/IconButton";
+import DeleteIcon from "@mui/icons-material/Delete";
+import { Tooltip } from "@mui/material";
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import "../../css/lesson/LessonDelete.css";
+
+const LessonDelete = ({ deleteLesson }) => {
+  const [open, setOpen] = React.useState(false);
+
+  const handleClickOpen = (event) => {
+    setOpen(true);
+  };
+
+  const handleClose = (event) => {
+    setOpen(false);
+  };
+
+  const handleDelete = (event) => {
+    deleteLesson();
+    setOpen(false);
+  };
+
+  return (
+    <div className="lesson-delete">
+      <Tooltip title="Delete Lesson">
+        <IconButton
+          edge="start"
+          color="error"
+          size="large"
+          aria-label="close"
+          className="dialog-close-button"
+          onClick={handleClickOpen}
+        >
+          <DeleteIcon className="lesson-delete-icon" />
+        </IconButton>
+      </Tooltip>
+       <Dialog
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="delete-dialog-title"
+        aria-describedby="delete-dialog-description"
+      >
+        <DialogTitle id="delete-dialog-title">
+          {"Are you sure you want to delete this lesson?"}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText id="delete-dialog-description">
+            This action cannot be undone and the lesson will be permanently deleted.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions >
+          <Button className="delete-confirm-btn" onClick={handleClose} color="primary">Cancel</Button>
+          <Button className="delete-confirm-btn" variant="contained" onClick={handleDelete} autoFocus color="error">
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
+
+export default LessonDelete;

--- a/src/components/lesson/LessonDialog.jsx
+++ b/src/components/lesson/LessonDialog.jsx
@@ -13,7 +13,7 @@ const Transition = React.forwardRef(function Transition(props, ref) {
   return <Slide direction="down" ref={ref} {...props} />;
 });
 
-const LessonDialog = ({ open, handleClose, lesson, scoreClass }) => {
+const LessonDialog = ({ open, handleClose, lesson, scoreClass, updateLessonScore }) => {
   const [startClicked, setStartClicked] = useState(false);
 
   const handleStartClick = () => {
@@ -47,7 +47,7 @@ const LessonDialog = ({ open, handleClose, lesson, scoreClass }) => {
       <div className="dialog-content">
         <h2 className="lesson-score">
           Score:{" "}
-          <span className={`lesson-score-${scoreClass}`}>{lesson.score}</span>
+          <span className={`lesson-score-${scoreClass}`}>{lesson.score}/100</span>
         </h2>
         <div className="container">
           <h3 className="lesson-title">{lesson.title}</h3>
@@ -66,9 +66,11 @@ const LessonDialog = ({ open, handleClose, lesson, scoreClass }) => {
 
           {startClicked && (
             <LessonReview
+              id={lesson.id}
               tests={lesson.tests}
               handleSubmitClick={handleSubmitClick}
               handleClose={handleClose}
+              updateLessonScore={updateLessonScore}
             />
           )}
         </div>

--- a/src/components/lesson/LessonEdit.jsx
+++ b/src/components/lesson/LessonEdit.jsx
@@ -1,0 +1,336 @@
+import React, { useState } from "react";
+import IconButton from "@mui/material/IconButton";
+import EditNoteIcon from "@mui/icons-material/EditNote";
+import { Tooltip } from "@mui/material";
+import "../../css/lesson/LessonEdit.css";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText";
+import DialogTitle from "@mui/material/DialogTitle";
+import Radio from "@mui/material/Radio";
+import RadioGroup from "@mui/material/RadioGroup";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import FormControl from "@mui/material/FormControl";
+import FormLabel from "@mui/material/FormLabel";
+import DeleteIcon from "@mui/icons-material/Delete";
+
+const LessonEdit = ({ lesson, updateLesson }) => {
+  const [open, setOpen] = useState(false);
+  const [selectedLevel, setSelectedLevel] = useState(lesson.level);
+  const [tests, setTests] = useState(lesson.tests);
+  const [options, setOptions] = useState(lesson.tests.options || []);
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+
+    const formElement = document.getElementById("edit-lesson-form");
+    const formData = new FormData(formElement);
+    const formJson = Object.fromEntries(formData.entries());
+    const { editTitle, editDescription, editLevel, editContent } = formJson;
+
+    if (
+      !editTitle ||
+      !editLevel ||
+      !editDescription ||
+      !editContent ||
+      tests.length === 0
+    ) {
+      alert("Please fill in all fields and ensure there is at least one test.");
+      return;
+    }
+
+    const updatedLesson = {
+      id: lesson.id,
+      title: editTitle,
+      level: editLevel,
+      description: editDescription,
+      score: lesson.score,
+      content: editContent.split("\n"),
+      tests: tests,
+    };
+
+    handleClose();
+    console.log(updatedLesson);
+    updateLesson(updatedLesson);
+    formElement.reset();
+  };
+
+  const handleEditOption = () => {
+    const optionsInput = document.getElementById("editOption").value;
+
+    if (!optionsInput) {
+      alert("Please make sure the option is not empty.");
+      return;
+    }
+
+    setOptions([...options, optionsInput]);
+    document.getElementById("editOption").value = "";
+  };
+
+  const handleEditTest = () => {
+    const questionInput = document.getElementById("editQuestion").value;
+    const answerInput = document.getElementById("editAnswer").value;
+
+    if (!questionInput || !answerInput) {
+      alert("Please make sure the question and answer are not empty.");
+      return;
+    }
+
+    if (options.length < 2) {
+      alert("Please make sure there are at least two options.");
+      return;
+    }
+
+    const newTest = {
+      question: questionInput,
+      options: options,
+      answer: answerInput,
+    };
+
+    setTests([...tests, newTest]);
+
+    // Clear the input fields after editing the test
+    document.getElementById("editQuestion").value = "";
+    document.getElementById("editAnswer").value = "";
+    setOptions([]);
+  };
+
+  const handleDeleteTest = (index) => {
+    setTests(tests.filter((_, i) => i !== index));
+  };
+
+  const handleDeleteOption = (index) => {
+    setOptions(options.filter((_, i) => i !== index));
+  };
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <div className="lesson-edit">
+      <Tooltip title="Edit Lesson">
+        <IconButton
+          edge="start"
+          color="info"
+          size="large"
+          aria-label="close"
+          className="dialog-close-button"
+          onClick={handleClickOpen}
+        >
+          <EditNoteIcon className="lesson-edit-icon" />
+        </IconButton>
+      </Tooltip>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        PaperProps={{
+          component: "form",
+          onSubmit: handleSubmit,
+          id: "edit-lesson-form",
+        }}
+      >
+        <DialogTitle className="edit-lesson-dialog-title">
+          Edit a lesson
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText className="edit-lesson-dialog-tip">
+            Update the title, level, description, content and the tests for the existing
+            lesson.
+          </DialogContentText>
+          <FormControl className="edit-lesson-dialog-form">
+            <TextField
+              className="edit-lesson-dialog-textfield"
+              autoFocus
+              required
+              fullWidth
+              margin="dense"
+              id="editTitle"
+              name="editTitle"
+              label="Title"
+              type="text"
+              variant="outlined"
+              defaultValue={lesson.title}
+            />
+
+            <TextField
+              className="edit-lesson-dialog-textfield"
+              required
+              margin="dense"
+              id="editDescription"
+              name="editDescription"
+              label="Description"
+              type="text"
+              variant="outlined"
+              defaultValue={lesson.description}
+            />
+
+            <FormLabel id="edit-lesson-dialog-level">Level</FormLabel>
+            <RadioGroup
+              className="edit-lesson-dialog-radio-group"
+              aria-labelledby="edit-lesson-group-label"
+              name="editLevel"
+              value={selectedLevel}
+              onChange={(event) => setSelectedLevel(event.target.value)}
+            >
+              <FormControlLabel
+                id="beginner-radio"
+                value="beginner"
+                control={<Radio />}
+                label="Beginner"
+              />
+              <FormControlLabel
+                id="intermediate-radio"
+                value="intermediate"
+                control={<Radio />}
+                label="Intermediate"
+              />
+              <FormControlLabel
+                id="advanced-radio"
+                value="advanced"
+                control={<Radio />}
+                label="Advanced"
+              />
+            </RadioGroup>
+
+            <TextField
+              margin="dense"
+              id="edit-lesson-dialog-content"
+              name="editContent"
+              label="Content"
+              type="text"
+              multiline
+              rows={4}
+              defaultValue={lesson.content.join("\n")}
+            />
+
+            <div className="edit-lesson-tests-wrapper">
+              <h2 className="edit-lesson-test-title">Review</h2>
+              <TextField
+                className="edit-lesson-dialog-textfield"
+                margin="dense"
+                id="editQuestion"
+                name="editQuestion"
+                label="Question"
+                type="text"
+                fullWidth
+                variant="outlined"
+              />
+
+              <TextField
+                className="edit-lesson-dialog-textfield edit-lesson-dialog-answer"
+                margin="dense"
+                id="editAnswer"
+                name="editAnswer"
+                label="Answer"
+                type="text"
+                fullWidth
+                variant="outlined"
+              />
+
+              <div className="edit-option-wrapper">
+                <TextField
+                  className="edit-lesson-dialog-textfield edit-lesson-dialog-option"
+                  margin="dense"
+                  id="editOption"
+                  name="editOption"
+                  label="Option"
+                  type="text"
+                  variant="outlined"
+                />
+                <button
+                  className="edit-option-btn"
+                  type="button"
+                  onClick={handleEditOption}
+                >
+                  Add option
+                </button>
+              </div>
+
+              <div className="edited-options">
+                {options.length > 0 && (
+                  <h2 className="edited-options-title">Options</h2>
+                )}
+                {options.map((option, index) => (
+                  <div key={index} className="edited-option">
+                    <p className="edited-option-text">
+                      {index + 1}: {option}
+                    </p>
+                    <Tooltip title="Delete Option">
+                      <IconButton
+                        edge="start"
+                        color="error"
+                        size="large"
+                        aria-label="close"
+                        className="delete-option-btn"
+                        onClick={() => handleDeleteOption(index)}
+                      >
+                        <DeleteIcon className="lesson-delete-icon" />
+                      </IconButton>
+                    </Tooltip>
+                  </div>
+                ))}
+              </div>
+
+              <button
+                className="edit-lesson-test-btn"
+                type="button"
+                onClick={handleEditTest}
+              >
+                Add test
+              </button>
+
+              <div className="edited-tests">
+                {tests.length > 0 && (
+                  <h2 className="edited-tests-title">Tests</h2>
+                )}
+                {tests.map((test, index) => (
+                  <div key={index} className="edited-test">
+                    <p className="edited-test-question">
+                      {index + 1}: {test.question}
+                    </p>
+                    <Tooltip title="Delete Test">
+                      <IconButton
+                        edge="start"
+                        color="error"
+                        size="large"
+                        aria-label="close"
+                        className="delete-test-btn"
+                        onClick={() => handleDeleteTest(index)}
+                      >
+                        <DeleteIcon className="lesson-delete-icon" />
+                      </IconButton>
+                    </Tooltip>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </FormControl>
+        </DialogContent>
+        <DialogActions>
+          <Button className="edit-lesson-dialog-btn" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button
+            className="edit-lesson-dialog-btn"
+            color="success"
+            variant="contained"
+            type="submit"
+            onClick={handleSubmit}
+          >
+            Update 
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
+
+export default LessonEdit;

--- a/src/components/lesson/LessonFilter.jsx
+++ b/src/components/lesson/LessonFilter.jsx
@@ -1,0 +1,46 @@
+import React, { useState } from "react";
+import "../../css/lesson/LessonFilter.css";
+
+const LessonFilter = ({ onFilterChange }) => {
+  const [activeFilter, setActiveFilter] = useState("all");
+
+  const handleFilterChange = (newFilter) => {
+    setActiveFilter(newFilter);
+    onFilterChange(newFilter);
+  };
+
+  return (
+    <div className="lesson-filter">
+      <button
+        id="btn-filter-all"
+        className={`btn-filter ${activeFilter === "all" ? "active" : ""}`}
+        onClick={() => handleFilterChange("all")}
+      >
+        All
+      </button>
+      <button
+        id="btn-filter-beginner"
+        className={`btn-filter ${activeFilter === "beginner" ? "active" : ""}`}
+        onClick={() => handleFilterChange("beginner")}
+      >
+        Beginner
+      </button>
+      <button
+        id="btn-filter-intermediate"
+        className={`btn-filter ${activeFilter === "intermediate" ? "active" : ""}`}
+        onClick={() => handleFilterChange("intermediate")}
+      >
+        Intermediate
+      </button>
+      <button
+        id="btn-filter-advanced"
+        className={`btn-filter ${activeFilter === "advanced" ? "active" : ""}`}
+        onClick={() => handleFilterChange("advanced")}
+      >
+        Advanced
+      </button>
+    </div>
+  );
+};
+
+export default LessonFilter;

--- a/src/components/lesson/LessonList.jsx
+++ b/src/components/lesson/LessonList.jsx
@@ -1,75 +1,65 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import "../../css/lesson/LessonList.css";
 import Lesson from "./Lesson";
+import LessonAdd from "./LessonAdd";
+import defaultLessons from "../../assets/data/defaultLessons.json";
+import LessonFilter from "./LessonFilter";
 
 const LessonList = () => {
-  let lessons = [
-    {
-      title: "Lesson 1: Greetings",
-      level: "Beginner",
-      description:
-        "Learn how to greet people in different situations and contexts.",
-      score: 0,
-      content: [
-        "Greetings are an important way to start a conversation and show respect and courtesy towards others. Here are some common greetings you can use:",
-        "Ciao",
-        "It's the most common informal greeting. It can be used to say both hello and goodbye. For example: Ciao, how are you? or Ciao, see you later!",
-        "Buongiorno",
-        "It means good morning and is used in the morning until midday. It can be shortened to Buon giorno. For example: Buongiorno, how are you today?",
-        "Buonasera",
-        "This means good evening and is used in the late afternoon and evening. For example: Buonasera, how was your day?",
-        "Buonanotte",
-        "It means goodnight and is used when saying goodbye in the evening or before going to bed. For example: Buonanotte, sleep well!",
-        "Salve",
-        "This is a neutral and formal greeting that can be used at any time of the day. It's a bit like saying hello. For example: Salve, nice to meet you.",
-      ],
-      tests: [
-        {
-          question: "What does 'Ciao' mean?",
-          options: ["Good morning", "Hello", "Good afternoon", "Good evening"],
-          answer: "Hello",
-        },
-        {
-          question: "When can you use 'Buongiorno'?",
-          options: [
-            "In the morning",
-            "In the afternoon",
-            "In the evening",
-            "At night",
-          ],
-          answer: "In the morning",
-        },
-        {
-          question: "What is 'Salve' similar to?",
-          options: ["Good morning", "Hello", "Good afternoon", "Good evening"],
-          answer: "Hello",
-        },
-      ],
-    },
-    {
-      title: "Lesson 15: Travel",
-      level: "Intermediate",
-      description:
-        "Learn how to ask for directions and order food at a restaurant.",
-      score: 40,
-      content: [],
-      tests: [],
-    },
-    {
-      title: "Lesson 30: Business",
-      level: "Advanced",
-      description:
-        "Learn how to write a professional email and give a presentation.",
-      score: 100,
-      content: [
-        "Dear Sir/Madam,",
-        "I am writing to enquire about the job vacancy.",
-      ],
-      tests: [],
-    },
-  ];
+  const storedLessons = localStorage.getItem("lessons");
+  const initialLessons = storedLessons
+    ? JSON.parse(storedLessons)
+    : defaultLessons;
+  const [lessons, setLessons] = useState(initialLessons);
+  const [filter, setFilter] = useState("all");
 
-  console.log(lessons);
+  const handleFilterChange = (newFilter) => {
+    setFilter(newFilter);
+  };
+  const filteredLessons = lessons.filter(
+    (lesson) => filter === "all" || lesson.level === filter
+  );
+
+  // ADD lesson
+  const addLesson = (newLesson) => {
+    setLessons([...lessons, newLesson]);
+  };
+
+  // UPDATE entire lesson
+  const updateLesson = (updatedLesson) => {
+    const updatedLessons = lessons.map((lesson) =>
+      lesson.id === updatedLesson.id ? updatedLesson : lesson
+    );
+    setLessons(updatedLessons);
+  };
+
+  // UPDATE lesson score
+  const updateLessonScore = (lessonId, newScore) => {
+    const updatedLessons = lessons.map((lesson) =>
+      lesson.id === lessonId ? { ...lesson, score: newScore } : lesson
+    );
+    setLessons(updatedLessons);
+  };
+
+  // DELETE lesson
+  const deleteLesson = (id) => {
+    setLessons(lessons.filter((lesson) => lesson.id !== id));
+  };
+
+  // Load lessons from local storage
+  useEffect(() => {
+    const storedLessons = localStorage.getItem("lessons");
+    if (storedLessons) {
+      setLessons(JSON.parse(storedLessons));
+    }
+  }, []);
+
+  // Save lessons to local storage
+  useEffect(() => {
+    localStorage.setItem("lessons", JSON.stringify(lessons));
+  }, [lessons]);
+
+  const lessonWrapperClass = filteredLessons.length < 3 ? 'lessons-wrapper lessons-wrapper-small' : 'lessons-wrapper';
 
   return (
     <section id="lessons" className="section">
@@ -82,14 +72,30 @@ const LessonList = () => {
           </p>
         </div>
 
-        <div className="section-content">
+        <div className={`section-content ${lessonWrapperClass}`}>
+          <LessonAdd addLesson={addLesson} />
+          <LessonFilter onFilterChange={handleFilterChange} />
+
           <div className="lesson-list">
-            {lessons.length > 0 ? (
-              lessons.map((lesson, index) => (
-                <Lesson key={index} lesson={lesson} />
+            {filteredLessons.length > 0 ? (
+              filteredLessons.map((lesson) => (
+                <Lesson
+                  key={lesson.id}
+                  lesson={lesson}
+                  updateLesson={updateLesson}
+                  updateLessonScore={updateLessonScore}
+                  deleteLesson={deleteLesson}
+                />
               ))
             ) : (
-              <p>No lessons available</p>
+              <div className="no-lessons-info">
+                <p className="no-lessons-list">
+                  No {filter !== "all" ? filter : ""} lessons available
+                </p>
+                <p className="yes-lessons-list">
+                  Add your first {filter !== "all" ? filter : ""} lesson!
+                </p>
+              </div>
             )}
           </div>
         </div>

--- a/src/components/lesson/LessonQuestion.jsx
+++ b/src/components/lesson/LessonQuestion.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import Radio from '@mui/material/Radio';
 import RadioGroup from '@mui/material/RadioGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
@@ -6,13 +6,23 @@ import FormControl from '@mui/material/FormControl';
 import FormLabel from '@mui/material/FormLabel';
 import '../../css/lesson/LessonQuestion.css';
 
-const LessonQuestion = ({ question, options }) => {
+const LessonQuestion = ({ question, options, opOptionChange }) => {
+  const [selectedOption, setSelectedOption] = useState(null);
+
+  const handleOptionChange = (event) => {
+    setSelectedOption(event.target.value);
+    opOptionChange(event.target.value);
+  };
+
   return (
     <FormControl>
       <FormLabel id="test-group-label">{question}</FormLabel>
       <RadioGroup
+        className="test-buttons-group"
         aria-labelledby="test-group-label"
         name="test-buttons-group"
+        value={selectedOption}
+        onChange={handleOptionChange}
       >
         {options.map((option, index) => (
           <FormControlLabel

--- a/src/components/lesson/LessonReview.jsx
+++ b/src/components/lesson/LessonReview.jsx
@@ -1,9 +1,36 @@
-import React from 'react';
-import LessonQuestion from './LessonQuestion';
-import '../../css/lesson/LessonReview.css';
+import React, { useState } from "react";
+import LessonQuestion from "./LessonQuestion";
+import "../../css/lesson/LessonReview.css";
 
-const LessonReview = ({ tests, handleSubmitClick, handleClose }) => {
- const handleFinishClick = () => {
+const LessonReview = ({ id, tests, handleSubmitClick, handleClose, updateLessonScore }) => {
+  const [selectedAnswers, setSelectedAnswers] = useState(
+    Array(tests.length).fill(null)
+  );
+
+  const handleOptionChange = (id, selectedOption) => {
+    const newSelectedAnswers = [...selectedAnswers];
+    newSelectedAnswers[id] = selectedOption;
+    setSelectedAnswers(newSelectedAnswers);
+  };
+
+  const handleFinishClick = () => {
+    const allAnswered = selectedAnswers.every((answer) => answer !== null);
+    if (!allAnswered) {
+      alert("Please answer all questions before submitting.");
+      return;
+    }
+
+     // Assuming tests[i].correctAnswer holds the correct answer for each test
+    const correctAnswersCount = selectedAnswers.reduce((count, answer, index) => {
+      return answer === tests[index].answer ? count + 1 : count;
+    }, 0);
+
+    let score = (correctAnswersCount / tests.length) * 100;
+    if(isNaN(score)) {
+      score = 0;
+    }
+    updateLessonScore(id, Math.trunc(score));
+
     handleSubmitClick();
     handleClose();
   };
@@ -18,6 +45,9 @@ const LessonReview = ({ tests, handleSubmitClick, handleClose }) => {
               <LessonQuestion
                 question={test.question}
                 options={test.options}
+                opOptionChange={(selectedOption) =>
+                  handleOptionChange(index, selectedOption)
+                }
               />
             </div>
           ))
@@ -25,7 +55,9 @@ const LessonReview = ({ tests, handleSubmitClick, handleClose }) => {
           <p className="no-tests">This lesson has no tests.</p>
         )}
       </div>
-      <button className="dialog-btn-submit" onClick={handleFinishClick}>Submit</button>
+      <button className="dialog-btn-submit" onClick={handleFinishClick}>
+        Submit
+      </button>
     </div>
   );
 };

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -29,6 +29,10 @@ body {
   overflow-x: hidden;
 }
 
+input {
+  font-family: 'Courier New', 'Raleway', Arial, sans-serif;
+}
+
 .container {
   width: 80vw;
   margin: 0 auto;

--- a/src/css/lesson/Lesson.css
+++ b/src/css/lesson/Lesson.css
@@ -1,26 +1,16 @@
+.lessons-wrapper .lesson-wrapper {
+  flex-basis: 30%;
+}
+
+.lessons-wrapper-small .lesson-wrapper {
+  flex-basis: auto;
+}
+
 .lesson {
-  width: 700px;
   padding: 1.5rem;
   border-radius: 3px;
   background-color: var(--secondary-color);
   color: var(--primary-color-contrast);
-  cursor: pointer;
-  transition: var(--default-transition);
-  transition-duration: 0.25s;
-
-  &:hover {
-    background-color: var(--primary-color-dark);
-    color: var(--secondary-color);
-
-    .lesson-level {
-      background-color: var(--secondary-color);
-      color: var(--primary-color);
-    }
-
-    .lesson-score span {
-      color: var(--highlight-color);
-    }
-  }
 }
 
 .lesson-title,
@@ -41,6 +31,10 @@
   border-radius: 20px;
   color: var(--secondary-color);
   background-color: var(--default-background-color); 
+
+  &::first-letter {
+    text-transform: uppercase;
+  }
 }
 
 .lesson-level-beginner {
@@ -60,6 +54,7 @@
   font-style: italic;
   font-weight: 600;
   letter-spacing: 0.03rem;
+  line-height: 1.5;
 }
 
 .lesson-score {
@@ -78,4 +73,32 @@
 
 .lesson-score-high {
   color: var(--success-color);
+}
+
+.lesson-operations-wrapper {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.start-lesson-btn {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 5px;
+  background-color: var(--primary-color-contrast);
+  color: var(--secondary-color);
+  font-weight: bold;
+  cursor: pointer;
+  transition: var(--default-transition);
+  transition-duration: 0.2s;
+
+  &:hover {
+    background-color: var(--success-color);
+  }
+}
+
+.lesson-operations {
+  display: flex;
+  border-radius: 5px;
 }

--- a/src/css/lesson/LessonAdd.css
+++ b/src/css/lesson/LessonAdd.css
@@ -1,0 +1,116 @@
+.lesson-add {
+  padding: 0rem 1rem;
+  background-color: var(--secondary-color);
+  margin-bottom: 1.5rem;
+  color: var(--primary-color-contrast);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.lesson-add-title {
+  margin-right: 1rem;
+}
+
+.add-lesson-dialog-title,
+.add-lesson-dialog-tip,
+.add-lesson-dialog-textfield label,
+.add-lesson-dialog-textfield input,
+.add-lesson-dialog-btn,
+#add-lesson-dialog-level,
+.add-lesson-dialog-radio-group span {
+  font-family: var(--default-font) !important;
+}
+
+.add-lesson-dialog-title {
+  font-weight: bold !important;
+}
+
+.add-lesson-dialog-btn {
+  font-weight: bold !important;
+}
+
+.add-lesson-dialog-form {
+  width: 100%;
+}
+
+#add-lesson-dialog-level {
+  margin-top: 1rem;
+}
+
+.add-lesson-dialog-radio-group {
+  margin-bottom: 1rem;
+}
+
+.add-lesson-test-title {
+  font-size: 1.3rem;
+  margin: 1rem 0 0.5rem;
+}
+
+.add-lesson-test-btn {
+  background-color: var(--success-color);
+  border: none;
+  cursor: pointer;
+  padding: 0.5rem 1rem;
+  border-radius: 3px;
+  font-weight: bold;
+  color: var(--secondary-color);
+  border: 2px solid var(--success-color);
+  transition: var(--default-transition);
+  margin-top: 1rem;
+  width: 100%;
+
+  &:hover {
+    background-color: var(--secondary-color);
+    color: var(--success-color);
+  }
+}
+
+.add-option-wrapper {
+  display: flex;
+  align-items: center;
+}
+
+.add-lesson-dialog-option {
+  width: 75%;
+}
+
+.add-option-btn {
+  background-color: var(--success-color);
+  border: none;
+  cursor: pointer;
+  padding: 1rem 0.5rem;
+  border-radius: 3px;
+  font-weight: bold;
+  color: var(--secondary-color);
+  border: 2px solid var(--success-color);
+  transition: var(--default-transition);
+  margin-left: 1rem;
+
+  &:hover {
+    background-color: var(--secondary-color);
+    color: var(--success-color);
+  }
+}
+
+.added-tests {
+  margin-bottom: 2rem;
+}
+
+.added-test,
+.added-option {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.added-tests-title,
+.added-options-title {
+  font-size: 1.25rem;
+  margin: 1rem 0 0.5rem;
+}
+
+.added-test-question,
+.added-option-text {
+  font-size: 1.25rem;
+}

--- a/src/css/lesson/LessonDelete.css
+++ b/src/css/lesson/LessonDelete.css
@@ -1,0 +1,14 @@
+#delete-dialog-title,
+#delete-dialog-description {
+  font-family: var(--default-font) !important;
+}
+
+#delete-dialog-description {
+  font-style: italic;
+  font-size: 1.1rem;
+}
+
+.delete-confirm-btn {
+  font-weight: bold !important;  
+  font-family: var(--default-font) !important;
+} 

--- a/src/css/lesson/LessonEdit.css
+++ b/src/css/lesson/LessonEdit.css
@@ -1,0 +1,114 @@
+.lesson-edit {
+  background-color: var(--secondary-color);
+  color: var(--primary-color-contrast);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.lesson-edit-title {
+  margin-right: 1rem;
+}
+
+.edit-lesson-dialog-title,
+.edit-lesson-dialog-tip,
+.edit-lesson-dialog-textfield label,
+.edit-lesson-dialog-textfield input,
+.edit-lesson-dialog-btn,
+#edit-lesson-dialog-level,
+.edit-lesson-dialog-radio-group span {
+  font-family: var(--default-font) !important;
+}
+
+.edit-lesson-dialog-title {
+  font-weight: bold !important;
+}
+
+.edit-lesson-dialog-btn {
+  font-weight: bold !important;
+}
+
+.edit-lesson-dialog-form {
+  width: 100%;
+}
+
+#edit-lesson-dialog-level {
+  margin-top: 1rem;
+}
+
+.edit-lesson-dialog-radio-group {
+  margin-bottom: 1rem;
+}
+
+.edit-lesson-test-title {
+  font-size: 1.3rem;
+  margin: 1rem 0 0.5rem;
+}
+
+.edit-lesson-test-btn {
+  background-color: var(--success-color);
+  border: none;
+  cursor: pointer;
+  padding: 0.5rem 1rem;
+  border-radius: 3px;
+  font-weight: bold;
+  color: var(--secondary-color);
+  border: 2px solid var(--success-color);
+  transition: var(--default-transition);
+  margin-top: 1rem;
+  width: 100%;
+
+  &:hover {
+    background-color: var(--secondary-color);
+    color: var(--success-color);
+  }
+}
+
+.edit-option-wrapper {
+  display: flex;
+  align-items: center;
+}
+
+.edit-lesson-dialog-option {
+  width: 75%;
+}
+
+.edit-option-btn {
+  background-color: var(--success-color);
+  border: none;
+  cursor: pointer;
+  padding: 1rem 0.5rem;
+  border-radius: 3px;
+  font-weight: bold;
+  color: var(--secondary-color);
+  border: 2px solid var(--success-color);
+  transition: var(--default-transition);
+  margin-left: 1rem;
+
+  &:hover {
+    background-color: var(--secondary-color);
+    color: var(--success-color);
+  }
+}
+
+.edited-tests {
+  margin-bottom: 2rem;
+}
+
+.edited-test,
+.edited-option {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.edited-tests-title,
+.edited-options-title {
+  font-size: 1.25rem;
+  margin: 1rem 0 0.5rem;
+}
+
+.edited-test-question,
+.edited-option-text {
+  font-size: 1.25rem;
+}

--- a/src/css/lesson/LessonFilter.css
+++ b/src/css/lesson/LessonFilter.css
@@ -1,0 +1,42 @@
+.lesson-filter {
+  background-color: var(--secondary-color);
+  padding: 1rem;
+  border-radius: 3px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 3rem;
+}
+
+.btn-filter {
+  background-color: var(--default-background-color);
+  color: var(--secondary-color);
+  font-weight: bold;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  border: none;
+  border-radius: 3px;
+  transition: var(--default-transition);
+
+  &:hover {
+    opacity: 0.85;
+  }
+}
+
+#btn-filter-all.active {
+  background-color: var(--primary-color-contrast);
+}
+
+#btn-filter-beginner.active {
+  background-color: var(--success-color);
+}
+
+#btn-filter-intermediate.active {
+  background-color: var(--highlight-color);
+  color: var(--primary-color-contrast);
+}
+
+#btn-filter-advanced.active {
+  background-color: var(--primary-color);
+}

--- a/src/css/lesson/LessonList.css
+++ b/src/css/lesson/LessonList.css
@@ -1,7 +1,33 @@
 .lesson-list {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
   justify-content: center;
   align-items: center;
   gap: 3rem;
+}
+
+.lessons-wrapper {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.no-lessons-info {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.no-lessons-list {
+  color: var(--highlight-color);
+  font-weight: bold;
+  font-size: 1.6rem;
+  margin-bottom: 0.5rem;
+}
+
+.yes-lessons-list {
+  color: var(--secondary-color);
+  font-weight: bold;
 }

--- a/src/css/lesson/LessonQuestion.css
+++ b/src/css/lesson/LessonQuestion.css
@@ -1,3 +1,7 @@
 #test-group-label {
   font-weight: bold;
 }
+
+.test-buttons-group span {
+  font-family: var(--default-font) !important;
+}


### PR DESCRIPTION
# Changes:
## Lesson
- Add possibility to create a lesson from scratch even with tests
- Add possibility to update and delete the lesson
- Add possibility to filter lessons based on the level of the lesson
- Add score calculation based on the length of `tests` array and right answers
- Add validation for creating, updating and reviewing

## Data
- Store `lessons` array in `localStorage`. Initially, it uses the `defaultLessons` array
- Move `defaultLssons` to separate `JSON` file, since it was getting too big
