### PR TITLE
refactor: add custom hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
         "react-scripts": "5.0.1",
+        "use-between": "^1.3.5",
         "web-vitals": "^2.1.4"
       }
     },
@@ -18007,6 +18008,14 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-between": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/use-between/-/use-between-1.3.5.tgz",
+      "integrity": "sha512-IP9eJfszZr0aah/6i/pzaM7n/QgMPwWKJ+mnWqT5O0qFhLnztPbkVC6L7zI6ygeBIMJHfmUGvsw0b28pyrEGSA==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "react-scripts": "5.0.1",
+    "use-between": "^1.3.5",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/App.js
+++ b/src/App.js
@@ -1,37 +1,26 @@
-import { useState, useEffect } from "react";
 import About from "./components/section/About";
 import Features from "./components/section/Features";
 import Footer from "./components/section/Footer";
 import Header from "./components/section/Header";
 import LessonList from "./components/lesson/LessonList";
 import Navbar from "./components/section/Navbar";
-import { ThemeContext } from "./context/ThemeContext";
 import Contact from "./components/section/Contact";
+import { useBetween } from "use-between";
+import { useTheme } from "./hooks/useTheme";
 
 function App() {
-  const [isDark, setIsDark] = useState(() => {
-    const saved = localStorage.getItem("isDark");
-    const initialValue = JSON.parse(saved);
-    return initialValue || false;
-  });
-  const color = isDark ? "#00ADB5" : "#fff";
-  
-  useEffect(() => {
-    localStorage.setItem("isDark", JSON.stringify(isDark));
-  }, [isDark]);
+  const { isDark, toggleTheme } = useBetween(useTheme);
 
   return (
-    <ThemeContext.Provider value={{ isDark, color }}>
-      <div data-theme={isDark ? "dark" : false}>
-        <Navbar isClicked={isDark} handleChange={() => setIsDark(!isDark)} />
-        <Header />
-        <Features />
-        <LessonList />
-        <About />
-        <Contact />
-        <Footer />
-      </div>
-    </ThemeContext.Provider>
+    <div data-theme={isDark ? "dark" : false}>
+      <Navbar isClicked={isDark} handleChange={toggleTheme} />
+      <Header />
+      <Features />
+      <LessonList />
+      <About />
+      <Contact />
+      <Footer />
+    </div>
   );
 }
 

--- a/src/components/lesson/Lesson.jsx
+++ b/src/components/lesson/Lesson.jsx
@@ -4,7 +4,7 @@ import LessonDialog from "./LessonDialog";
 import LessonDelete from "./LessonDelete";
 import LessonEdit from "./LessonEdit";
 
-const Lesson = ({ lesson, updateLesson, updateLessonScore, deleteLesson }) => {
+const Lesson = ({ lesson }) => {
   let scoreClass = "";
   if (lesson.score < 30) {
     scoreClass = "low";
@@ -41,8 +41,8 @@ const Lesson = ({ lesson, updateLesson, updateLessonScore, deleteLesson }) => {
         <div className="lesson-operations-wrapper">
           <button className="start-lesson-btn" onClick={handleClickOpen}>Start lesson</button>
           <div className="lesson-operations">
-            <LessonEdit lesson={lesson} updateLesson={updateLesson} />
-            <LessonDelete deleteLesson={() => deleteLesson(lesson.id)} />
+            <LessonEdit lesson={lesson} />
+            <LessonDelete lesson={lesson} />
           </div>
         </div>
       </div>
@@ -52,7 +52,6 @@ const Lesson = ({ lesson, updateLesson, updateLessonScore, deleteLesson }) => {
         handleClose={handleClose}
         lesson={lesson}
         scoreClass={scoreClass}
-        updateLessonScore={updateLessonScore}
       />
     </div>
   );

--- a/src/components/lesson/LessonAdd.jsx
+++ b/src/components/lesson/LessonAdd.jsx
@@ -16,13 +16,17 @@ import FormControlLabel from "@mui/material/FormControlLabel";
 import FormControl from "@mui/material/FormControl";
 import FormLabel from "@mui/material/FormLabel";
 import DeleteIcon from "@mui/icons-material/Delete";
-import { ThemeContext } from "../../context/ThemeContext";
+import { useBetween } from "use-between";
+import { useTheme } from "../../hooks/useTheme";
+import { useLessons } from "../../hooks/useLessons";
 
-const LessonAdd = ({ addLesson }) => {
+const LessonAdd = () => {
+  const { addLesson } = useBetween(useLessons);
   const [open, setOpen] = useState(false);
   const [selectedLevel, setSelectedLevel] = useState(null);
   const [tests, setTests] = useState([]);
   const [options, setOptions] = useState([]);
+  const { color } = useBetween(useTheme); 
 
   const handleSubmit = (event) => {
     event.preventDefault();
@@ -115,8 +119,6 @@ const LessonAdd = ({ addLesson }) => {
   const handleClose = () => {
     setOpen(false);
   };
-
-  const { color } = React.useContext(ThemeContext);
 
   return (
     <div className="lesson-add">

--- a/src/components/lesson/LessonDelete.jsx
+++ b/src/components/lesson/LessonDelete.jsx
@@ -9,25 +9,27 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
 import "../../css/lesson/LessonDelete.css";
-import { ThemeContext } from "../../context/ThemeContext";
+import { useBetween } from "use-between";
+import { useTheme } from "../../hooks/useTheme";
+import { useLessons } from "../../hooks/useLessons";
 
-const LessonDelete = ({ deleteLesson }) => {
+const LessonDelete = ({ lesson }) => {
+  const { deleteLesson } = useBetween(useLessons);
   const [open, setOpen] = React.useState(false);
+  const { color } = useBetween(useTheme);
 
-  const handleClickOpen = (event) => {
+  const handleClickOpen = () => {
     setOpen(true);
   };
 
-  const handleClose = (event) => {
+  const handleClose = () => {
     setOpen(false);
   };
 
-  const handleDelete = (event) => {
-    deleteLesson();
+  const handleDelete = () => {
+    deleteLesson(lesson.id);
     setOpen(false);
   };
-
-  const { color } = React.useContext(ThemeContext);
 
   return (
     <div className="lesson-delete">

--- a/src/components/lesson/LessonDialog.jsx
+++ b/src/components/lesson/LessonDialog.jsx
@@ -8,7 +8,8 @@ import CloseIcon from "@mui/icons-material/Close";
 import Slide from "@mui/material/Slide";
 import LessonContent from "./LessonContent";
 import LessonReview from "./LessonReview";
-import { ThemeContext } from "../../context/ThemeContext";
+import { useBetween } from "use-between";
+import { useTheme } from "../../hooks/useTheme";
 
 const Transition = React.forwardRef(function Transition(props, ref) {
   return <Slide direction="down" ref={ref} {...props} />;
@@ -18,11 +19,10 @@ const LessonDialog = ({
   open,
   handleClose,
   lesson,
-  scoreClass,
-  updateLessonScore,
+  scoreClass
 }) => {
   const [startClicked, setStartClicked] = useState(false);
-  const { color } = React.useContext(ThemeContext);
+  const { color } = useBetween(useTheme); 
 
   const handleStartClick = () => {
     setStartClicked(true);
@@ -81,11 +81,9 @@ const LessonDialog = ({
 
           {startClicked && (
             <LessonReview
-              id={lesson.id}
-              tests={lesson.tests}
+              lesson={lesson}
               handleSubmitClick={handleSubmitClick}
               handleClose={handleClose}
-              updateLessonScore={updateLessonScore}
             />
           )}
         </div>

--- a/src/components/lesson/LessonEdit.jsx
+++ b/src/components/lesson/LessonEdit.jsx
@@ -16,9 +16,13 @@ import FormControlLabel from "@mui/material/FormControlLabel";
 import FormControl from "@mui/material/FormControl";
 import FormLabel from "@mui/material/FormLabel";
 import DeleteIcon from "@mui/icons-material/Delete";
-import { ThemeContext } from "../../context/ThemeContext";
+import { useBetween } from "use-between";
+import { useTheme } from "../../hooks/useTheme";
+import { useLessons } from "../../hooks/useLessons";
 
-const LessonEdit = ({ lesson, updateLesson }) => {
+const LessonEdit = ({ lesson }) => {
+  const { updateLesson } = useBetween(useLessons);
+  const { color } = useBetween(useTheme); 
   const [open, setOpen] = useState(false);
   const [selectedLevel, setSelectedLevel] = useState(lesson.level);
   const [tests, setTests] = useState(lesson.tests);
@@ -54,7 +58,6 @@ const LessonEdit = ({ lesson, updateLesson }) => {
     };
 
     handleClose();
-    console.log(updatedLesson);
     updateLesson(updatedLesson);
     formElement.reset();
   };
@@ -114,8 +117,6 @@ const LessonEdit = ({ lesson, updateLesson }) => {
   const handleClose = () => {
     setOpen(false);
   };
-
-  const { color } = React.useContext(ThemeContext);
 
   return (
     <div className="lesson-edit">

--- a/src/components/lesson/LessonList.jsx
+++ b/src/components/lesson/LessonList.jsx
@@ -1,16 +1,13 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import "../../css/lesson/LessonList.css";
 import Lesson from "./Lesson";
 import LessonAdd from "./LessonAdd";
-import defaultLessons from "../../assets/data/defaultLessons.json";
 import LessonFilter from "./LessonFilter";
+import { useBetween } from "use-between";
+import { useLessons } from "../../hooks/useLessons";
 
 const LessonList = () => {
-  const storedLessons = localStorage.getItem("lessons");
-  const initialLessons = storedLessons
-    ? JSON.parse(storedLessons)
-    : defaultLessons;
-  const [lessons, setLessons] = useState(initialLessons);
+  const { lessons } = useBetween(useLessons);
   const [filter, setFilter] = useState("all");
 
   const handleFilterChange = (newFilter) => {
@@ -20,46 +17,10 @@ const LessonList = () => {
     (lesson) => filter === "all" || lesson.level === filter
   );
 
-  // ADD lesson
-  const addLesson = (newLesson) => {
-    setLessons([...lessons, newLesson]);
-  };
-
-  // UPDATE entire lesson
-  const updateLesson = (updatedLesson) => {
-    const updatedLessons = lessons.map((lesson) =>
-      lesson.id === updatedLesson.id ? updatedLesson : lesson
-    );
-    setLessons(updatedLessons);
-  };
-
-  // UPDATE lesson score
-  const updateLessonScore = (lessonId, newScore) => {
-    const updatedLessons = lessons.map((lesson) =>
-      lesson.id === lessonId ? { ...lesson, score: newScore } : lesson
-    );
-    setLessons(updatedLessons);
-  };
-
-  // DELETE lesson
-  const deleteLesson = (id) => {
-    setLessons(lessons.filter((lesson) => lesson.id !== id));
-  };
-
-  // Load lessons from local storage
-  useEffect(() => {
-    const storedLessons = localStorage.getItem("lessons");
-    if (storedLessons) {
-      setLessons(JSON.parse(storedLessons));
-    }
-  }, []);
-
-  // Save lessons to local storage
-  useEffect(() => {
-    localStorage.setItem("lessons", JSON.stringify(lessons));
-  }, [lessons]);
-
-  const lessonWrapperClass = filteredLessons.length < 3 ? 'lessons-wrapper lessons-wrapper-small' : 'lessons-wrapper';
+  const lessonWrapperClass =
+    filteredLessons.length < 3
+      ? "lessons-wrapper lessons-wrapper-small"
+      : "lessons-wrapper";
 
   return (
     <section id="lessons" className="section">
@@ -73,7 +34,7 @@ const LessonList = () => {
         </div>
 
         <div className={`section-content ${lessonWrapperClass}`}>
-          <LessonAdd addLesson={addLesson} />
+          <LessonAdd />
           <LessonFilter onFilterChange={handleFilterChange} />
 
           <div className="lesson-list">
@@ -82,9 +43,6 @@ const LessonList = () => {
                 <Lesson
                   key={lesson.id}
                   lesson={lesson}
-                  updateLesson={updateLesson}
-                  updateLessonScore={updateLessonScore}
-                  deleteLesson={deleteLesson}
                 />
               ))
             ) : (

--- a/src/components/lesson/LessonReview.jsx
+++ b/src/components/lesson/LessonReview.jsx
@@ -1,10 +1,13 @@
 import React, { useState } from "react";
 import LessonQuestion from "./LessonQuestion";
 import "../../css/lesson/LessonReview.css";
+import { useBetween } from "use-between";
+import { useLessons } from "../../hooks/useLessons";
 
-const LessonReview = ({ id, tests, handleSubmitClick, handleClose, updateLessonScore }) => {
+const LessonReview = ({ lesson, handleSubmitClick, handleClose }) => {
+  const { updateLesson } = useBetween(useLessons);
   const [selectedAnswers, setSelectedAnswers] = useState(
-    Array(tests.length).fill(null)
+    Array(lesson.tests.length).fill(null)
   );
 
   const handleOptionChange = (id, selectedOption) => {
@@ -20,16 +23,20 @@ const LessonReview = ({ id, tests, handleSubmitClick, handleClose, updateLessonS
       return;
     }
 
-     // Assuming tests[i].correctAnswer holds the correct answer for each test
+    // Assuming tests[i].correctAnswer holds the correct answer for each test
     const correctAnswersCount = selectedAnswers.reduce((count, answer, index) => {
-      return answer === tests[index].answer ? count + 1 : count;
+      return answer === lesson.tests[index].answer ? count + 1 : count;
     }, 0);
 
-    let score = (correctAnswersCount / tests.length) * 100;
+    let score = (correctAnswersCount / lesson.tests.length) * 100;
     if(isNaN(score)) {
       score = 0;
     }
-    updateLessonScore(id, Math.trunc(score));
+    let updatedLesson = {
+      ...lesson,
+      score: Math.trunc(score),
+    };
+    updateLesson(updatedLesson);
 
     handleSubmitClick();
     handleClose();
@@ -39,8 +46,8 @@ const LessonReview = ({ id, tests, handleSubmitClick, handleClose, updateLessonS
     <div className="dialog-tests-wrapper">
       <h3 className="dialog-tests-title">Review</h3>
       <div className="tests">
-        {tests.length > 0 ? (
-          tests.map((test, index) => (
+        {lesson.tests.length > 0 ? (
+          lesson.tests.map((test, index) => (
             <div key={index} className="dialog-test">
               <LessonQuestion
                 question={test.question}

--- a/src/context/ThemeContext.jsx
+++ b/src/context/ThemeContext.jsx
@@ -1,3 +1,0 @@
-import React from 'react';
-
-export const ThemeContext = React.createContext();

--- a/src/hooks/useLessons.jsx
+++ b/src/hooks/useLessons.jsx
@@ -1,0 +1,46 @@
+import { useState, useEffect } from 'react';
+import defaultLessons from '../assets/data/defaultLessons.json';
+
+const useLessons = () => {
+  const [lessons, setLessons] = useState(() => {
+    const storedLessons = localStorage.getItem('lessons');
+    return storedLessons ? JSON.parse(storedLessons) : defaultLessons;
+  });
+
+  // ADD lesson
+  const addLesson = (newLesson) => {
+    setLessons([...lessons, newLesson]);
+  };
+
+  // UPDATE entire lesson
+  const updateLesson = (updatedLesson) => {
+    const updatedLessons = lessons.map((lesson) =>
+      lesson.id === updatedLesson.id ? updatedLesson : lesson
+    );
+    setLessons(updatedLessons);
+  };
+
+  // DELETE lesson
+  const deleteLesson = (id) => {
+    setLessons(lessons.filter((lesson) => lesson.id !== id));
+  };
+
+  // Load lessons from local storage
+  useEffect(() => {
+    const storedLessons = localStorage.getItem('lessons');
+    if (storedLessons) {
+      setLessons(JSON.parse(storedLessons));
+    }
+  }, []);
+
+  // Save lessons to local storage
+  useEffect(() => {
+    localStorage.setItem('lessons', JSON.stringify(lessons));
+    setLessons(lessons);
+  }, [lessons]);
+
+  return { lessons, addLesson, updateLesson, deleteLesson };
+};
+
+export { useLessons }
+export default useLessons;

--- a/src/hooks/useTheme.jsx
+++ b/src/hooks/useTheme.jsx
@@ -1,0 +1,20 @@
+import { useState, useEffect } from "react";
+
+const useTheme = () => {
+  const [isDark, setIsDark] = useState(() => {
+    const saved = localStorage.getItem("isDark");
+    const initialValue = JSON.parse(saved);
+    return initialValue || false;
+  });
+
+  const color = isDark ? "#00ADB5" : "#fff";
+
+  useEffect(() => {
+    localStorage.setItem("isDark", JSON.stringify(isDark));
+  }, [isDark]);
+
+  return { isDark, color, toggleTheme: () => setIsDark(!isDark) };
+};
+
+export { useTheme };
+export default useTheme;


### PR DESCRIPTION
# Changes:
## Libraries:
- [`useBetween`](https://www.npmjs.com/package/use-between?activeTab=readme) - a way to call any hook, so that the state will not be stored in the React component. For the same hook, the result of the call will be the same. 

## Hooks:
- `useLessons` - a custom hook that lets you share stateful logic, not [state](https://react.dev/learn/reusing-logic-with-custom-hooks#custom-hooks-let-you-share-stateful-logic-not-state-itself) itself, in this case the `lessons` array. This will remove [prop drilling](https://react.dev/learn/passing-data-deeply-with-context#the-problem-with-passing-props).
- `useTheme` - remove [`Context API`](https://react.dev/reference/react/useContext) implementation for a custom hook 